### PR TITLE
Recalculate cols instead of rows

### DIFF
--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -61,8 +61,8 @@ export function getGridItemDimensions({ count, dimensions, aspectRatio, gap }: C
 		b = Math.floor((H + s) / (h + s))
 
 		if (a * b >= N) {
-			// recalculate rows, as row calculated above can be inaccurate
-			b = Math.ceil(N / a)
+			// recalculate cols, as col calculated above can be inaccurate
+			a = Math.ceil(N / b)
 			break
 		}
 	}


### PR DESCRIPTION
Since tiles are distributed horizontally into rows first, recalculating columns will optimize for tile density catching certain corner cases.

Before:
<img width="2672" alt="image" src="https://github.com/user-attachments/assets/531684d5-21dd-4d4f-9148-5e4777dcd393" />

After:
<img width="2672" alt="image" src="https://github.com/user-attachments/assets/41929e06-d0f6-4db4-8f31-b35f965657fe" />
