### PR TITLE
Recalculate both rows and columns

### DIFF
--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -61,8 +61,9 @@ export function getGridItemDimensions({ count, dimensions, aspectRatio, gap }: C
 		b = Math.floor((H + s) / (h + s))
 
 		if (a * b >= N) {
-			// recalculate cols, as col calculated above can be inaccurate
+			// recalculate rows and cols, as row and col calculated above can be inaccurate
 			a = Math.ceil(N / b)
+			b = Math.ceil(N / a)
 			break
 		}
 	}

--- a/package/src/react/index.ts
+++ b/package/src/react/index.ts
@@ -26,7 +26,7 @@ export function useGridDimensions($el: RefObject<HTMLElement>) {
 		return () => {
 			observer.disconnect()
 		}
-	}, [])
+	}, [$el])
 
 	return dimensions
 }


### PR DESCRIPTION
It turned out that only recalculating columns instead of rows solved one funky layout issue, but introduced a new one. By recalculating both, we solve this!

Before (was calculating 4 rows):
<img width="1351" alt="image" src="https://github.com/user-attachments/assets/2e3c247e-686e-456b-9f4d-b912983cc731" />

After: (now correctly calculating 3 rows):
<img width="1351" alt="image" src="https://github.com/user-attachments/assets/056dbebb-e90d-4ac1-86a9-c1a081c9898b" />

